### PR TITLE
allow log handle to be provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ os:
   - linux
 
 julia:
-  - 1.0
   - 1.1
   - 1.2
   - 1.3
+  - 1.4
   - nightly
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,14 @@ uuid = "7d4ad63e-389f-5fab-a457-725f5c98637d"
 keywords = ["openresty", "nginx", "julia"]
 license = "MIT"
 desc = "Launch and manage Openresty (Nginx) from Julia"
-version = "0.1.0"
+version = "0.1.5"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
-julia = "≥ 1.0.0"
+julia = "≥ 1.1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Accept optional parameters in start and restart methods through which the caller can provide a handle to write logs into.

```julia
function start(ctx::OpenrestyCtx;
        accesslog=nothing, errorlog=nothing,
        append::Bool=(isa(accesslog,AbstractString)||isa(errorlog,AbstractString)))
end
function restart(ctx::OpenrestyCtx; delay_seconds::Int=0,
        accesslog=nothing, errorlog=nothing,
        append::Bool=(isa(accesslog,AbstractString)||isa(errorlog,AbstractString)))
end
```

Dropping Julia 1.0.0 compatibility, to allow `pipeline` to work with `PipeBuffer`.