### PR TITLE
Handle corrupt PID files

### DIFF
--- a/src/Openresty.jl
+++ b/src/Openresty.jl
@@ -177,8 +177,16 @@ end
 function readpid(ctx::OpenrestyCtx)
     pfile = pidfile(ctx)
     if isfile(pfile)
-        ctx.pid = parse(Int, read(pidfile(ctx), String))
-        isrunning(ctx)
+        pid = tryparse(Int, read(pfile, String))
+        if isnothing(pid)
+            @warn "Removing corrupted PID file: $(pfile)"
+            # The `rm` may throw if the process doesn't have the the permissions
+            # to remove the PID file.
+            rm(pfile)
+            ctx.pid = nothing
+        else
+            isrunning(ctx)
+        end
     else
         ctx.pid = nothing
     end

--- a/src/Openresty.jl
+++ b/src/Openresty.jl
@@ -177,13 +177,12 @@ end
 function readpid(ctx::OpenrestyCtx)
     pfile = pidfile(ctx)
     if isfile(pfile)
-        pid = tryparse(Int, read(pfile, String))
-        if isnothing(pid)
+        ctx.pid = tryparse(Int, read(pfile, String))
+        if isnothing(ctx.pid)
             @warn "Removing corrupted PID file: $(pfile)"
             # The `rm` may throw if the process doesn't have the the permissions
             # to remove the PID file.
             rm(pfile)
-            ctx.pid = nothing
         else
             isrunning(ctx)
         end


### PR DESCRIPTION
If the PID file is corrupt (e.g. exists, but is empty for some reason), just go ahead and remove it, and assume it wasn't there in the first place.

Similar to https://github.com/tanmaykm/Dex.jl/pull/10, but doesn't throw (unless removing the PID file fails somehow). Or do we want it to throw if there is a bad PID file?